### PR TITLE
feat(azure-cost): 비용 수집기 공용화 + 멀티유저 문서화 (issue #596)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,40 @@ $env:LOCALAPPDATA\GIIP\logs\
 
 **권장:** PowerShell 에이전트 사용
 
+## 🗂️ 레포 / 기밀 분리 구조 (중요 — 혼동 주의)
+
+이 폴더(`giipAgentWin/`)는 **그 자체가 독립 git 저장소**다: `git@github.com:LowyShin/giipAgentWin.git`.
+여러 서버·여러 사용자가 이 저장소를 clone 해 **공용(public) 스크립트**를 공유한다.
+
+- ✅ **공용(저장소에 커밋)**: `giipscripts/*.ps1`, `lib/*.ps1`, `giipAgent.cfg.example`(플레이스홀더 템플릿) 등 코드.
+- 🔒 **기밀(저장소 밖, 절대 커밋 금지)**: 실 `giipAgent.cfg`(각자의 `sk`/`lssn`/Azure SPN 시크릿).
+  이 저장소 **폴더 밖**에 둔다 → ① `giipAgentWin`의 **부모 디렉터리**(예: `…/giipAgent/giipAgent.cfg`),
+  또는 ② `%USERPROFILE%\giipAgent.cfg`. 설정 로더(`lib/Common.ps1: Get-GiipConfig`)가 이 순서로 찾으며,
+  머리글에 `SAMPLE`이 있으면 **템플릿으로 간주해 건너뛴다**(실수로 예제를 실설정으로 쓰는 것 방지).
+
+> ⚠️ **자주 하는 오해:** `giipAgent/` **루트**에서 `git status`를 돌리면 "not a git repository"가 나온다.
+> 그렇다고 스크립트가 비-git인 게 **아니다** — 저장소는 한 단계 아래 `giipAgent/giipAgentWin/`이다.
+> 정본 코드는 `LowyShin/giipAgentWin`에 있고, 기밀만 부모 폴더(비-git)에 있다.
+
+## 💰 Azure 비용 수집기 (멀티유저)
+
+`giipscripts/azure-cost-put-win.ps1` — Azure Cost Management API로 구독 비용을 수집해 GIIP KVS(`kFactor=azure_cost`)에 적재하는 **독립 실행형** 스크립트. **서비스별(`by_service`)과 리소스 그룹별(`by_resource_group`) 두 축**을 함께 수집한다.
+
+사용자마다 **자기 계정 정보**로 수집하려면:
+
+1. `giipAgent.cfg.example`을 **저장소 밖**으로 복사한다(위 "레포/기밀 분리" 참고): 부모 폴더 또는 `%USERPROFILE%\giipAgent.cfg`.
+2. 복사본에 본인 값을 채운다: `sk`, `lssn`, 그리고 무인 실행용 Azure 서비스 주체 `az_subscription`/`az_client_id`/`az_client_secret`/`az_tenant_id`(생략 시 대화형 `az login` 세션 사용).
+3. 실행/등록:
+   ```powershell
+   # 수동 실행(최근 7일)
+   .\giipscripts\azure-cost-put-win.ps1 -Days 7
+   # 매일 06:00 예약 작업 등록
+   .\giipscripts\azure-cost-put-win.ps1 -Register -AtTime "06:00"
+   ```
+
+- 조회 페이지(giipv3): 서비스별 `/{locale}/azure-cost`, 리소스 그룹별 `/{locale}/azure-cost-rg`.
+- 상세 사양: `giipdb/docs/30_Specs/AZURE_COST_COLLECTOR_SPECIFICATION.md`(giipdb 저장소).
+
 ## 📞 지원
 
 - **GitHub**: https://github.com/LowyShin/giipAgentWin

--- a/giipAgent.cfg.example
+++ b/giipAgent.cfg.example
@@ -27,3 +27,15 @@ debug = "0"
 
 # Git Branch for Agent Auto-Update
 branch = "real"
+
+# ===================================================================
+# Azure Cost Collector (azure-cost-put-win.ps1) — OPTIONAL
+# ===================================================================
+# Target subscription (optional; else uses current az default subscription)
+# az_subscription = "00000000-0000-0000-0000-000000000000"
+#
+# Service principal for non-interactive scheduled runs (optional).
+# If omitted, the script relies on an existing interactive 'az login'.
+# az_client_id     = "YOUR_APP_ID"
+# az_client_secret = "YOUR_APP_SECRET"
+# az_tenant_id     = "YOUR_TENANT_ID"

--- a/giipscripts/azure-cost-put-win.ps1
+++ b/giipscripts/azure-cost-put-win.ps1
@@ -1,0 +1,215 @@
+# ============================================================================
+# azure-cost-put-win.ps1
+# Purpose : Collect Azure usage & cost via Azure Cost Management API (az rest),
+#           save as JSON, and push the summary to GIIP KVS (kFactor="azure_cost").
+# Runs    : Standalone / independent of giipAgent3.ps1 module chain.
+#           Register as its own daily Scheduled Task with -Register.
+# Auth    : Uses the current 'az login' context, OR a service principal from
+#           giipAgent.cfg (az_client_id / az_client_secret / az_tenant_id).
+# API     : POST .../providers/Microsoft.CostManagement/query (works for MCA/EA/PAYG;
+#           az consumption usage list returns 'None' costs on MCA and is NOT used).
+# KVS     : lib/Kvs.ps1 -> Invoke-GiipKvsPut. jsondata MUST carry kValue (real data),
+#           otherwise the server stores an empty {} while returning 200 (silent loss).
+# ============================================================================
+
+[CmdletBinding()]
+param(
+    [switch]$Register,               # Register a daily Scheduled Task and exit
+    [string]$AtTime = "06:00",       # Daily run time (for -Register)
+    [string]$SubscriptionId,         # Target subscription (else cfg az_subscription / current)
+    [int]$Days = 0,                  # Last N days (Custom); 0 = MonthToDate
+    [string]$Factor = "azure_cost",  # KVS kFactor
+    [string]$OutFile                 # Raw JSON output path (else giipLogs\azure\...)
+)
+
+$ErrorActionPreference = "Stop"
+
+# --- Resolve paths and load shared libraries ---------------------------------
+$ScriptDir = Split-Path -Path $MyInvocation.MyCommand.Path -Parent
+$AgentRoot = Split-Path -Path $ScriptDir -Parent            # giipscripts -> giipAgentWin
+$LibDir    = Join-Path $AgentRoot "lib"
+$Global:BaseDir = $AgentRoot                                # so Get-GiipConfig finds ../giipAgent.cfg
+
+. (Join-Path $LibDir "Common.ps1")   # Get-GiipConfig, Invoke-GiipApiV2, Write-GiipLog
+. (Join-Path $LibDir "Kvs.ps1")      # Invoke-GiipKvsPut
+
+# --- -Register: install a daily Scheduled Task for this script and exit -------
+if ($Register) {
+    $self = $MyInvocation.MyCommand.Path
+    $taskName = "GIIP Azure Cost Collector"
+    $arg = "-WindowStyle Hidden -NonInteractive -ExecutionPolicy Bypass -File `"$self`""
+    $action    = New-ScheduledTaskAction -Execute "powershell.exe" -Argument $arg
+    $trigger   = New-ScheduledTaskTrigger -Daily -At $AtTime
+    $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive
+    Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Principal $principal -Force | Out-Null
+    Write-GiipLog "INFO" "Registered Scheduled Task '$taskName' (daily at $AtTime)."
+    return
+}
+
+# --- Load config -------------------------------------------------------------
+$Config = Get-GiipConfig
+if (-not $Config.lssn) { Write-GiipLog "ERROR" "lssn missing in giipAgent.cfg. Aborting."; exit 1 }
+
+# --- Ensure Azure CLI is available -------------------------------------------
+if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+    Write-GiipLog "ERROR" "Azure CLI (az) not found in PATH. Install it or run 'az login' first."
+    exit 1
+}
+
+# --- Optional: service-principal login (non-interactive scheduled runs) -------
+if ($Config.az_client_id -and $Config.az_client_secret -and $Config.az_tenant_id) {
+    Write-GiipLog "INFO" "Logging in with service principal ($($Config.az_client_id))."
+    az login --service-principal --username $Config.az_client_id --password $Config.az_client_secret --tenant $Config.az_tenant_id --only-show-errors --output none
+    if ($LASTEXITCODE -ne 0) { Write-GiipLog "ERROR" "az service-principal login failed."; exit 1 }
+}
+
+# --- Resolve subscription ----------------------------------------------------
+if (-not $SubscriptionId) { $SubscriptionId = $Config.az_subscription }
+if ($SubscriptionId) {
+    az account set --subscription $SubscriptionId --only-show-errors
+    if ($LASTEXITCODE -ne 0) { Write-GiipLog "ERROR" "az account set failed for $SubscriptionId."; exit 1 }
+}
+$acct = az account show --only-show-errors --output json 2>$null | ConvertFrom-Json
+if (-not $acct) { Write-GiipLog "ERROR" "No active Azure account. Run 'az login' or set service-principal creds."; exit 1 }
+$subId   = $acct.id
+$subName = $acct.name
+
+# --- Resolve shared timeframe once (both axes use the same period) ------------
+$today = Get-Date
+if ($Days -gt 0) {
+    $from = $today.AddDays(-$Days).ToString("yyyy-MM-ddT00:00:00+00:00")
+    $to   = $today.ToString("yyyy-MM-ddT23:59:59+00:00")
+    $timeframe  = "Custom"
+    $timePeriod = @{ from = $from; to = $to }
+    $periodDesc = "$from .. $to"
+} else {
+    $timeframe  = "MonthToDate"
+    $timePeriod = $null
+    $periodDesc = "MonthToDate"
+}
+
+$url = "https://management.azure.com/subscriptions/$subId/providers/Microsoft.CostManagement/query?api-version=2023-11-01"
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+
+# --- Cost Management query helper (grouped by a single dimension) --------------
+# Runs one ActualCost query grouped by $GroupDimension over the shared timeframe.
+# Cost Management enforces strict 429 rate limits -> retry up to 5x, 35s backoff.
+# az rest --body @file avoids shell-quoting issues (BOM-less UTF-8 temp file).
+# Returns @{ Raw = <json string>; Result = <parsed object> }, or hard-exits(1).
+function Invoke-CmQuery {
+    param([Parameter(Mandatory)][string]$GroupDimension)
+
+    $dataset = @{
+        granularity = "None"
+        aggregation = @{ totalCost = @{ name = "PreTaxCost"; function = "Sum" } }
+        grouping    = @( @{ type = "Dimension"; name = $GroupDimension } )
+    }
+    $bodyObj = @{ type = "ActualCost"; timeframe = $timeframe; dataset = $dataset }
+    if ($timePeriod) { $bodyObj.timePeriod = $timePeriod }
+    $bodyJson = $bodyObj | ConvertTo-Json -Depth 10 -Compress
+
+    $tmpBody = Join-Path $env:TEMP ("az_cm_body_{0}_{1}.json" -f $GroupDimension, $today.ToString("yyyyMMddHHmmssfff"))
+    [System.IO.File]::WriteAllText($tmpBody, $bodyJson, $utf8NoBom)
+
+    Write-GiipLog "INFO" "Querying Cost Management ($GroupDimension) for $subName ($subId): $periodDesc"
+    $rawJson = $null
+    for ($attempt = 1; $attempt -le 5; $attempt++) {
+        $rawJson = (az rest --method post --url $url --headers "Content-Type=application/json" --body "@$tmpBody" --only-show-errors --output json 2>&1 | Out-String)
+        if ($LASTEXITCODE -eq 0 -and $rawJson -notmatch '"?429"?') { break }
+        if ($rawJson -match '429') {
+            Write-GiipLog "WARN" "Rate-limited (429) on $GroupDimension. Retry $attempt/5 after 35s."
+            Start-Sleep -Seconds 35
+            continue
+        }
+        Write-GiipLog "ERROR" "Cost Management query ($GroupDimension) failed: $rawJson"
+        Remove-Item $tmpBody -ErrorAction SilentlyContinue
+        exit 1
+    }
+    Remove-Item $tmpBody -ErrorAction SilentlyContinue
+    if (-not $rawJson -or $rawJson -match '429') { Write-GiipLog "ERROR" "Cost Management query ($GroupDimension) still failing (429)."; exit 1 }
+
+    return @{ Raw = $rawJson; Result = ($rawJson | ConvertFrom-Json) }
+}
+
+# --- Query #1: by ServiceName (existing axis -> by_service) -------------------
+$svcQ   = Invoke-CmQuery -GroupDimension "ServiceName"
+$rawJson = $svcQ.Raw
+$result  = $svcQ.Result
+$cols = @($result.properties.columns.name)
+$rows = @($result.properties.rows)
+
+$iCost = [array]::IndexOf($cols, "PreTaxCost")
+$iSvc  = [array]::IndexOf($cols, "ServiceName")
+$iCur  = [array]::IndexOf($cols, "Currency")
+if ($iCost -lt 0) { Write-GiipLog "ERROR" "Unexpected response shape (no PreTaxCost column)."; exit 1 }
+
+# --- Save raw JSON (UTF-8, no BOM) — service-axis dump is the canonical raw ----
+if (-not $OutFile) {
+    $azDir = Join-Path $AgentRoot "..\giipLogs\azure"
+    if (-not (Test-Path $azDir)) { New-Item -Path $azDir -ItemType Directory -Force | Out-Null }
+    $OutFile = Join-Path $azDir ("azure_cost_{0}_{1}.json" -f $subId, $today.ToString("yyyyMMdd"))
+}
+[System.IO.File]::WriteAllText($OutFile, $rawJson, $utf8NoBom)
+Write-GiipLog "INFO" "Saved raw cost JSON ($($rows.Count) service rows) -> $OutFile"
+
+# --- Query #2: by ResourceGroupName (new axis -> by_resource_group) -----------
+# Feeds giipv3 azure-cost-rg/page.tsx (by_resource_group[{resource_group,cost}] + resource_group_count).
+$rgQ      = Invoke-CmQuery -GroupDimension "ResourceGroupName"
+$rgResult = $rgQ.Result
+$rgCols   = @($rgResult.properties.columns.name)
+$rgRows   = @($rgResult.properties.rows)
+$iRgCost  = [array]::IndexOf($rgCols, "PreTaxCost")
+$iRg      = [array]::IndexOf($rgCols, "ResourceGroupName")
+if ($iRg -lt 0) { $iRg = [array]::IndexOf($rgCols, "ResourceGroup") }  # API shape fallback
+
+$byResourceGroup = @()
+if ($iRgCost -ge 0) {
+    $rgList = foreach ($row in $rgRows) {
+        $rgName = if ($iRg -ge 0 -and $row[$iRg]) { [string]$row[$iRg] } else { "" }
+        [PSCustomObject]@{
+            resource_group = if ($rgName) { $rgName } else { "(unassigned)" }  # costs with no RG
+            cost           = [math]::Round([double]$row[$iRgCost], 4)
+        }
+    }
+    $byResourceGroup = @($rgList | Sort-Object cost -Descending)
+} else {
+    Write-GiipLog "WARN" "ResourceGroupName query returned no PreTaxCost column; by_resource_group left empty."
+}
+Write-GiipLog "INFO" "Collected $($byResourceGroup.Count) resource-group rows."
+
+# --- Summarize (this becomes kValue) -----------------------------------------
+$services = foreach ($row in $rows) {
+    [PSCustomObject]@{
+        service = if ($iSvc -ge 0) { $row[$iSvc] } else { "All" }
+        cost    = [math]::Round([double]$row[$iCost], 4)
+    }
+}
+$services = @($services | Sort-Object cost -Descending)
+$total = 0.0
+foreach ($row in $rows) { $total += [double]$row[$iCost] }
+$currency = if ($rows.Count -gt 0 -and $iCur -ge 0) { $rows[0][$iCur] } else { $null }
+
+$summary = [PSCustomObject]@{
+    subscription_id      = $subId
+    subscription_name    = $subName
+    period               = $periodDesc
+    currency             = $currency
+    total_pretax_cost    = [math]::Round($total, 4)
+    service_count        = $services.Count
+    by_service           = $services
+    resource_group_count = $byResourceGroup.Count
+    by_resource_group    = $byResourceGroup
+    collected_at         = $today.ToString("s")
+}
+
+# --- Push to GIIP KVS --------------------------------------------------------
+Write-GiipLog "INFO" "Pushing azure_cost to KVS (lssn=$($Config.lssn), total=$($summary.total_pretax_cost) $currency)."
+$resp = Invoke-GiipKvsPut -Config $Config -Type "lssn" -Key "$($Config.lssn)" -Factor $Factor -Value $summary
+
+if ($resp -and $resp.RstVal -eq "200") {
+    Write-GiipLog "INFO" "Azure cost uploaded successfully."
+} else {
+    $rv = if ($resp) { $resp.RstVal } else { "no-response" }
+    Write-GiipLog "ERROR" "KVS put failed (RstVal=$rv)."
+    exit 1
+}


### PR DESCRIPTION
## 목적
Azure 비용 수집기를 **공용 스크립트**로 이 저장소(LowyShin/giipAgentWin)에 편입하고, 여러 사용자가
**각자 계정 정보**로 수집할 수 있도록 문서화한다. 기밀은 저장소 밖(부모 폴더/%USERPROFILE%)에 유지.

## 변경
- **`giipscripts/azure-cost-put-win.ps1`** (신규 추적): 그동안 로컬 untracked 였던 수집기를 정식 편입.
  ServiceName/ResourceGroupName 두 축(`by_service`/`by_resource_group`+`resource_group_count`)을 KVS(`azure_cost`)에 적재.
- **`giipAgent.cfg.example`**: Azure Cost Collector용 선택 키 블록 추가(`az_subscription`, `az_client_id/secret/tenant`).
- **`README.md`**: 2개 섹션 추가 —
  - `🗂️ 레포 / 기밀 분리 구조`: 이 폴더=독립 git 저장소(공용), 실 `giipAgent.cfg`(기밀)는 저장소 밖(부모/홈)에.
    `giipAgent/` 루트에서 git이 안 잡히는 흔한 오해를 명시적으로 교정.
  - `💰 Azure 비용 수집기 (멀티유저)`: 각 사용자가 자기 cfg를 저장소 밖에 두고 실행/예약 등록하는 절차.

## 안전
스테이징된 것은 코드/플레이스홀더 템플릿뿐(`YOUR_KVS_TOKEN`/`YOUR_APP_ID` 등). 실 시크릿 없음.
저장소 밖 `giipAgent.cfg`(각자 값)는 커밋 대상이 아니며, `Get-GiipConfig`의 `SAMPLE` 가드가 예제 오사용을 차단.

## 검증
라이브 실행: RG 19행 수집 → `by_resource_group` 합계 = `total_pretax_cost`(365,536 KRW) 일치, KVS 200.

> 관련 PR: giipv3#152(메뉴 아이콘), giipdb#32(사양서), giipdb#33(메뉴 SQL). 메뉴 행은 이미 DB 반영됨.
> 참고: 이 브랜치에는 무관한 로컬 WIP(lib/Kvs.ps1, dpa-*, net-put-win, checkAgentHealth)는 포함하지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)