### PR TITLE
docs(cfg): azure-cost용 cfg.example 샘플·안내 명확화 (issue #596)

### DIFF
--- a/giipAgent.cfg.example
+++ b/giipAgent.cfg.example
@@ -8,6 +8,8 @@
 # 1. Copy this file to the PARENT directory of giipAgentWin
 # 2. Or place it in %USERPROFILE%\giipAgent.cfg
 # 3. Update the 'sk' and 'lssn' values in the copied file.
+# 4. (Azure cost collection only) Uncomment and fill the "Azure Cost
+#    Collector" section at the bottom — see the notes there.
 # ===================================================================
 
 # V2 API Endpoint
@@ -29,13 +31,20 @@ debug = "0"
 branch = "real"
 
 # ===================================================================
-# Azure Cost Collector (azure-cost-put-win.ps1) — OPTIONAL
+# Azure Cost Collector (azure-cost-put-win.ps1)
 # ===================================================================
-# Target subscription (optional; else uses current az default subscription)
-# az_subscription = "00000000-0000-0000-0000-000000000000"
+# Used for UNATTENDED / scheduled cost collection via a service principal.
+#   - Fill ALL of az_client_id/az_client_secret/az_tenant_id (and optionally
+#     az_subscription) to enable non-interactive scheduled runs.
+#   - Leave them commented to fall back to your current interactive 'az login'.
+# ⚠️ Do NOT uncomment while the values are still placeholders — the script
+#    would attempt an SPN login with fake credentials and fail. Uncomment only
+#    once you paste REAL values.
 #
-# Service principal for non-interactive scheduled runs (optional).
-# If omitted, the script relies on an existing interactive 'az login'.
-# az_client_id     = "YOUR_APP_ID"
-# az_client_secret = "YOUR_APP_SECRET"
-# az_tenant_id     = "YOUR_TENANT_ID"
+# Target subscription (optional; else uses the az default subscription):
+# az_subscription  = "00000000-0000-0000-0000-000000000000"
+#
+# Service principal (needs the 'Cost Management Reader' role on the subscription):
+# az_client_id     = "00000000-0000-0000-0000-000000000000"   # app (client) ID
+# az_client_secret = "your-client-secret-value"               # client secret VALUE (not the ID)
+# az_tenant_id     = "00000000-0000-0000-0000-000000000000"   # directory (tenant) ID


### PR DESCRIPTION
## 배경
PR #14로 `giipAgent.cfg.example`에 Azure 키 블록을 넣었으나 전부 주석 처리라
`sk`/`lssn`(활성 자리표시자)과 대비돼 "왜 없지?"로 혼동될 수 있었다.

## 변경 (`giipAgent.cfg.example`)
- HOW TO USE에 **4단계**(Azure 수집 시 하단 섹션 주석 해제·기입) 추가.
- Azure 섹션 자리표시자를 **GUID 형식**으로 교체(`YOUR_APP_ID` → `00000000-...`),
  각 키에 인라인 설명(app id / client secret **VALUE** / tenant id) 추가.
- **주석 유지가 안전 기본값**임을 명시: 채우면 무인 예약 실행(SPN), 비우면 대화형 `az login`.
  ⚠️ 자리표시자 상태로 주석 풀면 가짜 값으로 SPN 로그인 시도→실패(폴백 깨짐) 경고 추가.

## 왜 주석을 유지하나
수집기 로직 `if ($Config.az_client_id -and ...)` 은 값이 존재하면 SPN 로그인을 시도한다.
자리표시자를 활성화하면 가짜 자격증명으로 로그인해 실패하므로, 실제 값 입력 전엔 주석이 정답.

🤖 Generated with [Claude Code](https://claude.com/claude-code)