### PR TITLE
fix: use managed DB catalog for MSSQL connections

### DIFF
--- a/giipscripts/modules/DbConnectionList.ps1
+++ b/giipscripts/modules/DbConnectionList.ps1
@@ -30,12 +30,15 @@ function Get-MSSQLConnections {
         [Parameter(Mandatory = $true)][string]$DbHost,
         [Parameter(Mandatory = $true)][int]$Port,
         [Parameter(Mandatory = $true)][string]$User,
-        [Parameter(Mandatory = $true)][string]$Pass
+        [Parameter(Mandatory = $true)][string]$Pass,
+        [string]$Database
     )
     
     $builder = New-Object System.Data.SqlClient.SqlConnectionStringBuilder
     $builder.DataSource = "$DbHost,$Port"
-    $builder.InitialCatalog = "master"
+    if ($Database -and $Database.Trim()) {
+        $builder.InitialCatalog = $Database
+    }
     $builder.UserID = $User
     $builder.Password = $Pass
     $builder.TrustServerCertificate = $true
@@ -215,7 +218,8 @@ try {
         try {
             $connections = @()
             if ($db.db_type -eq 'MSSQL') {
-                $connections = Get-MSSQLConnections -DbHost $db.db_host -Port $db.db_port -User $db.db_user -Pass $db.db_password
+                $dbName = if ($db.db_database) { $db.db_database } elseif ($db.db_name) { $db.db_name } else { $null }
+                $connections = Get-MSSQLConnections -DbHost $db.db_host -Port $db.db_port -User $db.db_user -Pass $db.db_password -Database $dbName
             }
             elseif ($db.db_type -match 'MySQL|MariaDB') {
                 $connections = Get-MySQLConnections -DbHost $db.db_host -Port $db.db_port -User $db.db_user -Pass $db.db_password

--- a/giipscripts/modules/DbUserList.ps1
+++ b/giipscripts/modules/DbUserList.ps1
@@ -71,7 +71,10 @@ try {
                     # Use SqlConnectionStringBuilder to safely handle special characters in password
                     $connStrBuilder = New-Object System.Data.SqlClient.SqlConnectionStringBuilder
                     $connStrBuilder["Data Source"] = "$dbHost,$port"
-                    $connStrBuilder["Initial Catalog"] = "master"
+                    $dbName = if ($db.db_database) { $db.db_database } elseif ($db.db_name) { $db.db_name } else { $null }
+                    if ($dbName -and $dbName.Trim()) {
+                        $connStrBuilder["Initial Catalog"] = $dbName
+                    }
                     $connStrBuilder["User ID"] = $user
                     $connStrBuilder["Password"] = $pass
                     $connStrBuilder["TrustServerCertificate"] = $true

--- a/giipscripts/modules/SyncFullQuery.ps1
+++ b/giipscripts/modules/SyncFullQuery.ps1
@@ -32,7 +32,8 @@ foreach ($db in $dbList) {
     if ($db.db_type -ne 'MSSQL') { continue }
     
     try {
-        $connStr = "Server=$($db.db_host),$($db.db_port);Database=master;User Id=$($db.db_user);Password=$($db.db_password);TrustServerCertificate=True;Connection Timeout=10;"
+        $dbName = if ($db.db_database) { $db.db_database } elseif ($db.db_name) { $db.db_name } else { "master" }
+        $connStr = "Server=$($db.db_host),$($db.db_port);Database=$dbName;User Id=$($db.db_user);Password=$($db.db_password);TrustServerCertificate=True;Connection Timeout=10;"
         $conn = New-Object System.Data.SqlClient.SqlConnection($connStr)
         $conn.Open()
         

--- a/lib/DbCollector.ps1
+++ b/lib/DbCollector.ps1
@@ -26,6 +26,7 @@ function Get-GiipDbMetrics {
     $port = if ($DbInfo.port) { $DbInfo.port } else { $DbInfo.db_port }
     $user = if ($DbInfo.user) { $DbInfo.user } else { $DbInfo.db_user }
     $pass = if ($DbInfo.pass) { $DbInfo.pass } else { $DbInfo.db_password }
+    $dbName = if ($DbInfo.db_database) { $DbInfo.db_database } elseif ($DbInfo.db_name) { $DbInfo.db_name } else { $null }
 
     Write-GiipLog "INFO" "Collecting metrics for $dbType on $ip : $port"
 
@@ -44,6 +45,10 @@ function Get-GiipDbMetrics {
                 $connBuilder["Password"] = $pass
             } else {
                 $connBuilder["Integrated Security"] = $true
+            }
+            if ($dbName -and $dbName.Trim()) {
+                # Prefer managed DB name when available to avoid master/default-db permission issues.
+                $connBuilder["Initial Catalog"] = $dbName
             }
             $connBuilder["Connect Timeout"] = 15
             # Ensure compatibility with newer drivers/local certs


### PR DESCRIPTION
## Summary
- remove hard-coded master dependency in MSSQL connection paths
- use managed DB name (db_database then db_name) when provided
- keep existing behavior as fallback when DB name is unavailable

## Why
Some environments/users do not have permission to open master as default catalog. This caused DB monitor/collection failures on certain PCs even though credentials were valid for the target managed DB.

## Validation
- Ran giipAgent3.ps1 on this PC after patch
- Confirmed Step 3 DbMonitor no longer fails with Cannot open user default database / master permission error
- End-to-end run completed successfully
