### PR TITLE
feat: windowless launcher for giipAgent3 (git sync + run, no cmd window)

### DIFF
--- a/giipAgent3-launcher.ps1
+++ b/giipAgent3-launcher.ps1
@@ -1,0 +1,32 @@
+# ============================================================================
+# giipAgent3-launcher.ps1
+# Purpose: Windowless replacement for giipAgent3.bat.
+#          Runs git-auto-sync.ps1 (pull latest) then giipAgent3.ps1, all inside
+#          the SAME PowerShell process so no cmd.exe/console window is ever
+#          spawned. Intended as the Task Scheduler action target:
+#            powershell.exe -WindowStyle Hidden -NonInteractive -ExecutionPolicy Bypass -File "...\giipAgent3-launcher.ps1"
+# ============================================================================
+
+$ErrorActionPreference = "Stop"
+$ScriptDir = Split-Path -Path $MyInvocation.MyCommand.Path -Parent
+Set-Location $ScriptDir
+
+$syncScript = Join-Path $ScriptDir "git-auto-sync.ps1"
+if (Test-Path $syncScript) {
+    Write-Host "Starting Safe Git Sync..."
+    & $syncScript
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "ERROR: Sync failed. Agent will not start."
+        exit 1
+    }
+    Write-Host "Safe Git Sync completed successfully."
+} else {
+    Write-Host "WARN: git-auto-sync.ps1 not found at $syncScript. Skipping sync."
+}
+
+Write-Host "Starting giipAgent3.ps1..."
+$agentScript = Join-Path $ScriptDir "giipAgent3.ps1"
+& $agentScript
+$exitCode = $LASTEXITCODE
+Write-Host "giipAgent3.ps1 execution ended [ExitCode: $exitCode]"
+exit $exitCode


### PR DESCRIPTION
## Summary
- giipAgent3.bat pops a visible cmd window (shells via cmd.exe + `pause`) — this is what runs git-auto-sync before giipAgent3.ps1.
- Added `giipAgent3-launcher.ps1`, a pure-PowerShell replacement that runs `git-auto-sync.ps1` then `giipAgent3.ps1` inside the same process. No cmd.exe / Start-Process anywhere, so no window can ever appear.
- Intended as the new Task Scheduler action target: `powershell.exe -WindowStyle Hidden -NonInteractive -ExecutionPolicy Bypass -File "...\giipAgent3-launcher.ps1"`.

## Test plan
- [x] Ran the launcher directly: git sync (stash/checkout main/pull) succeeded, all 7 giipAgent3.ps1 steps completed, exit code 0.
- [x] Confirmed the script only invokes git.exe directly and calls other .ps1 files via `&`/dot-source — never cmd.exe or Start-Process — so it is safe under a hidden PowerShell host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)