### PR TITLE
fix: truly windowless task launch via wscript+vbs

### DIFF
--- a/TaskSchdReg.ps1
+++ b/TaskSchdReg.ps1
@@ -1,12 +1,16 @@
 ## Check for administrator privileges - Not required for User execution context
 # But needed for Register-ScheduledTask
 
-Write-Host "Re-registering Task Scheduler for giipAgent3.ps1 (5-min interval)..." -ForegroundColor Cyan
+Write-Host "Re-registering Task Scheduler for giipAgent3 (5-min interval, silent)..." -ForegroundColor Cyan
 
 $scriptDir = $PSScriptRoot
 if (-not $scriptDir) { $scriptDir = Get-Location }
 
-$targetScript = Join-Path $scriptDir "giipAgent3.ps1"
+# wscript.exe + a .vbs wrapper is used instead of "powershell.exe -WindowStyle Hidden"
+# directly: -WindowStyle Hidden still briefly flashes a console window on some
+# Windows builds/logon types, while WScript.Shell.Run with style 0 never
+# allocates a visible window at all.
+$targetScript = Join-Path $scriptDir "giipAgent3-silent.vbs"
 
 if (-not (Test-Path $targetScript)) {
     Write-Error "Target script not found: $targetScript"
@@ -14,7 +18,7 @@ if (-not (Test-Path $targetScript)) {
 }
 
 $taskName = "GIIP Agent Task (v3)"
-$action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-WindowStyle Hidden -NonInteractive -ExecutionPolicy Bypass -File `"$targetScript`""
+$action = New-ScheduledTaskAction -Execute "wscript.exe" -Argument "`"$targetScript`""
 $trigger = New-ScheduledTaskTrigger -Once -At "00:00" -RepetitionInterval (New-TimeSpan -Minutes 5)
 # Run as current user (Interactive or Background depending on login)
 # For specific User account execution without password, usually requires 'LogonType Interactive' or S4U.
@@ -22,7 +26,7 @@ $trigger = New-ScheduledTaskTrigger -Once -At "00:00" -RepetitionInterval (New-T
 $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive
 
 # Or use S4U (Do not store password) if rights allow
-# $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType S4U 
+# $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType S4U
 
 Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Principal $principal -Force
 

--- a/giipAgent3-launcher.ps1
+++ b/giipAgent3-launcher.ps1
@@ -3,8 +3,10 @@
 # Purpose: Windowless replacement for giipAgent3.bat.
 #          Runs git-auto-sync.ps1 (pull latest) then giipAgent3.ps1, all inside
 #          the SAME PowerShell process so no cmd.exe/console window is ever
-#          spawned. Intended as the Task Scheduler action target:
-#            powershell.exe -WindowStyle Hidden -NonInteractive -ExecutionPolicy Bypass -File "...\giipAgent3-launcher.ps1"
+#          spawned. Invoked via giipAgent3-silent.vbs (wscript.exe), which is
+#          the actual Task Scheduler action target - see TaskSchdReg.ps1.
+#          ("powershell.exe -WindowStyle Hidden" alone can still briefly
+#          flash a console window on some Windows builds/logon types.)
 # ============================================================================
 
 $ErrorActionPreference = "Stop"

--- a/giipAgent3-silent.vbs
+++ b/giipAgent3-silent.vbs
@@ -1,0 +1,22 @@
+' ============================================================================
+' giipAgent3-silent.vbs
+' Purpose: True windowless entry point for Task Scheduler.
+'          "powershell.exe -WindowStyle Hidden" still briefly flashes a
+'          console window on some Windows builds/logon types. WScript.Shell.Run
+'          with window style 0 never allocates a visible console at all, so
+'          this is the reliable fix. Task Scheduler action should target this
+'          file via: wscript.exe "...\giipAgent3-silent.vbs"
+' ============================================================================
+
+Dim objFSO, objShell, scriptDir, targetScript, cmd
+
+Set objFSO = CreateObject("Scripting.FileSystemObject")
+Set objShell = CreateObject("WScript.Shell")
+
+scriptDir = objFSO.GetParentFolderName(WScript.ScriptFullName)
+targetScript = scriptDir & "\giipAgent3-launcher.ps1"
+
+cmd = "powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File """ & targetScript & """"
+
+' 0 = hidden window, True = wait for completion
+objShell.Run cmd, 0, True


### PR DESCRIPTION
## Summary
- `-WindowStyle Hidden` on `powershell.exe` can still briefly flash a console window under Task Scheduler on some Windows builds/logon types (esp. `LogonType Interactive`).
- Adds `giipAgent3-silent.vbs`, which launches `giipAgent3-launcher.ps1` via `WScript.Shell.Run(cmd, 0, True)` - style `0` never allocates a visible window at all.
- `TaskSchdReg.ps1` now registers the scheduled task action as `wscript.exe "...\giipAgent3-silent.vbs"` instead of calling powershell directly.

## Test plan
- [x] Re-registered the local "GIIP Agent Task (v3)" scheduled task against the new vbs wrapper and confirmed it still runs giipAgent3.ps1 successfully (git-auto-sync log continues updating every 5 min) with no visible window.
- [ ] After merge, other deployed copies (per-server working copies) should `git pull` and re-run `TaskSchdReg.ps1` to pick up the change.