### PR TITLE
docs: fix stale master-branch link in sqlnet_put.bat

### DIFF
--- a/giipscripts/sqlnet_put.bat
+++ b/giipscripts/sqlnet_put.bat
@@ -1,6 +1,6 @@
 REM DPA - Database Performance Analysis
 REM sql server version
-REM mysql (on linux) : https://github.com/LowyShin/giipAgentLinux/blob/master/giipscripts/execmysql.sh
+REM mysql (on linux) : https://github.com/LowyShin/giipAgentLinux/blob/main/giipscripts/execmysql.sh
 
 REM call me when you want use DPA, we can help to use. contact@littleworld.net
 


### PR DESCRIPTION
## Summary
- Recovered from an old (Jan/Apr) local stash while cleaning up orphaned stashes on this checkout.
- `giipAgentLinux`'s default branch is `main`; the comment still pointed at `master`.

## Test plan
- Comment-only change, no functional impact.