### PR TITLE
fix(ga-collect.cqe.ps1): DB 저장 서비스계정 키 자동 조회 지원 (giip-803)

### DIFF
--- a/giipscripts/cqe/ga-collect.cqe.ps1
+++ b/giipscripts/cqe/ga-collect.cqe.ps1
@@ -12,17 +12,22 @@
 #   {{CustomVariables}} -> per-assignment custom_values injected as PS code
 #                          (giipdb pCQEForcebyUsn REPLACE). Must set:
 #                            $GaProperty  = 'properties/123456789'
-#                            $GaKeyFile   = 'C:\giip\ga-service-account.json'
 #                            $GaDispatcher= 'https://<giip byAK dispatcher url>'
-#                          optional: $GaFactor (default 'daily'), $GaRange (default 'yesterday')
+#                          optional: $GaKeyFile (local override path, skips DB fetch),
+#                                    $GaFactor (default 'daily'), $GaRange (default 'yesterday')
+#
+# giip-803: GA4 서비스계정 키는 서버에 파일로 미리 배치하지 않는다 — ga-property 화면에서
+#   입력/관리되는 값을 실행 시점에 pApiGaKeyGetbySk(자기 sk 인증)로 받아 임시파일로만 쓰고
+#   즉시 삭제한다(giipAgentLinux/cqe/ga-collect.cqe.sh 와 동일 방식으로 통일).
+#   $GaKeyFile 을 custom_values 로 명시 주입한 경우에만 로컬 파일을 우선한다.
 #
 # Remote PC prerequisites:
 #   - PowerShell 7 (pwsh) installed  (RSA PKCS#8 JWT signing). Body re-execs under pwsh.
-#   - GA4 service-account key JSON present at $GaKeyFile (NOT shipped in ms_body).
 #   - giipAgentWin running and polling CQE for this lssn.
 #
 # Registration: giipdb/mgmt/register-ga-cqe.ps1 (CQERepoPut + CQEQueuePut).
 # Spec: giip-678 / SPEC_20260720_GA_KVS_AI_REPORT.md T3 (CQE delivery variant)
+# giip-803: DB 기반 키 조회로 giipAgentLinux 와 동작을 통일.
 # ============================================================================
 
 $ErrorActionPreference = "Stop"
@@ -57,8 +62,35 @@ if ($PSVersionTable.PSVersion.Major -lt 6) {
 # --- Validate injected config ------------------------------------------------
 if (-not $GaProperty)   { GaLog "ERROR" "GaProperty not set (custom_values)."; exit 1 }
 if (-not $GaDispatcher) { GaLog "ERROR" "GaDispatcher not set (custom_values)."; exit 1 }
-if (-not $GaKeyFile -or -not (Test-Path $GaKeyFile)) { GaLog "ERROR" "GaKeyFile not found: '$GaKeyFile'."; exit 1 }
 if (-not $GiipToken -or $GiipToken -like '*{{*') { GaLog "ERROR" "GIIP token not injected."; exit 1 }
+
+# --- GA4 서비스계정 키 확보: 로컬 override 없으면 DB(ga-property 화면)에서 조회 ---
+$FetchedKeyFile = $null
+if (-not $GaKeyFile -or -not (Test-Path $GaKeyFile)) {
+    $keyPayload = @{ gaPropertyId = $GaProperty } | ConvertTo-Json -Compress
+    $keyForm = "text=" + [uri]::EscapeDataString("GaKeyGet gaPropertyId") +
+               "&token=" + [uri]::EscapeDataString($GiipToken) +
+               "&jsondata=" + [uri]::EscapeDataString($keyPayload)
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    $keyResp = Invoke-RestMethod -Method Post -Uri $GaDispatcher -ContentType 'application/x-www-form-urlencoded; charset=utf-8' -Body $keyForm -TimeoutSec 30
+
+    $keyB64 = $null
+    if ($keyResp) {
+        $keyB64 = $keyResp.gaKeyJsonB64
+        if (-not $keyB64 -and $keyResp.data) { $keyB64 = $keyResp.data[0].gaKeyJsonB64 }
+    }
+    if (-not $keyB64) {
+        $pm = $null
+        if ($keyResp) { $pm = $keyResp.Proc_MSG; if (-not $pm -and $keyResp.data) { $pm = $keyResp.data[0].Proc_MSG } }
+        if (-not $pm) { $pm = $keyResp | ConvertTo-Json -Compress -Depth 5 }
+        GaLog "ERROR" ("GaKeyGet failed (property not registered with a key on ga-property page?): " + $pm)
+        exit 1
+    }
+
+    $FetchedKeyFile = New-TemporaryFile
+    [IO.File]::WriteAllBytes($FetchedKeyFile.FullName, [Convert]::FromBase64String($keyB64))
+    $GaKeyFile = $FetchedKeyFile.FullName
+}
 
 function ConvertTo-Base64Url([byte[]]$Bytes) {
     return [Convert]::ToBase64String($Bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
@@ -131,4 +163,7 @@ try {
 catch {
     GaLog "ERROR" "GA CQE collect failed: $_"
     exit 1
+}
+finally {
+    if ($FetchedKeyFile -and (Test-Path $FetchedKeyFile.FullName)) { Remove-Item $FetchedKeyFile.FullName -Force -ErrorAction SilentlyContinue }
 }


### PR DESCRIPTION
## 배경
`giipAgentLinux/cqe/ga-collect.cqe.sh`는 giip-803에서 GA4 서비스계정 키를 서버에 파일로 미리 배치하지 않고 `pApiGaKeyGetbySk`로 DB(ga-property 화면에 등록된 값)에서 실행 시점에 조회하도록 이미 바뀌었는데, Windows판인 이 파일은 그대로였습니다 — `$GaKeyFile`이 로컬에 실제로 존재해야만 동작.

## 수정
- `$GaKeyFile`이 없거나 로컬에 없으면 `GaKeyGet gaPropertyId` 커맨드로 `giipApiSk3` 디스패처를 통해 `pApiGaKeyGetbySk`를 호출, base64로 받은 키를 임시파일에 써서 사용하고 실행 종료 시(`finally`) 삭제
- `$GaKeyFile`을 `custom_values`로 명시 주입한 경우는 기존처럼 로컬 파일을 우선 사용(override 가능, 하위호환)
- PS 5.1 파서가 `??` 연산자를 모르는데(CQE가 이 파일을 `powershell.exe` 5.1로 먼저 로드한 뒤 pwsh 7로 재-exec) 5.1 호환 문법으로 작성 — 파서 레벨에서 검증 완료

## 참고
이번에 이 저장소(csn 33 소속, lssn 71197)로는 실제 GA 수집 등록에 쓰지 않았습니다(대상 GA 속성이 csn 47 소속이라 다른 서버(lssn 71174, Linux)에 등록함). 이 수정은 향후 Windows 노드를 GA 수집기로 쓸 때를 위한 일반 개선입니다.

## Test plan
- [ ] `$GaKeyFile`을 비운 채(또는 미설정) CQE로 실제 배포해 DB 키 조회 경로가 동작하는지 확인
- [ ] `$GaKeyFile`을 명시 지정했을 때 기존처럼 로컬 파일이 우선되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)