### PR TITLE
fix(db-perf-diag): wire up orphaned dpa-put-mssql-perfdiag.ps1 + Query Store column bug (giip-922)

### DIFF
--- a/giipscripts/dpa-put-mssql-perfdiag.ps1
+++ b/giipscripts/dpa-put-mssql-perfdiag.ps1
@@ -90,18 +90,20 @@ function Get-MssqlPerfDiag {
     $regressQuery = @"
 SET NOCOUNT ON;
 ;WITH recent AS (
-    SELECT rs.query_id, AVG(rs.avg_duration) AS avg_dur_recent, SUM(rs.count_executions) AS exec_recent
+    SELECT p.query_id, AVG(rs.avg_duration) AS avg_dur_recent, SUM(rs.count_executions) AS exec_recent
     FROM sys.query_store_runtime_stats rs
+    JOIN sys.query_store_plan p ON rs.plan_id = p.plan_id
     JOIN sys.query_store_runtime_stats_interval rsi ON rs.runtime_stats_interval_id = rsi.runtime_stats_interval_id
     WHERE rsi.start_time >= DATEADD(MINUTE, -30, GETUTCDATE())
-    GROUP BY rs.query_id
+    GROUP BY p.query_id
 ),
 baseline AS (
-    SELECT rs.query_id, AVG(rs.avg_duration) AS avg_dur_baseline
+    SELECT p.query_id, AVG(rs.avg_duration) AS avg_dur_baseline
     FROM sys.query_store_runtime_stats rs
+    JOIN sys.query_store_plan p ON rs.plan_id = p.plan_id
     JOIN sys.query_store_runtime_stats_interval rsi ON rs.runtime_stats_interval_id = rsi.runtime_stats_interval_id
     WHERE rsi.start_time >= DATEADD(HOUR, -25, GETUTCDATE()) AND rsi.start_time < DATEADD(MINUTE, -30, GETUTCDATE())
-    GROUP BY rs.query_id
+    GROUP BY p.query_id
 )
 SELECT TOP 5
     r.query_id,

--- a/giipscripts/modules/DbMonitor.ps1
+++ b/giipscripts/modules/DbMonitor.ps1
@@ -56,6 +56,37 @@ $statsList = @()
 foreach ($db in $dbList) {
     try {
         Write-GiipLog "DEBUG" "[DbMonitor] DB Object: $($db | ConvertTo-Json -Compress)"
+
+        # giip-issue #922 follow-up (root cause for #921's db_perf_diag never appearing):
+        # giipscripts/dpa-put-mssql-perfdiag.ps1 (PR #26) was added as a standalone
+        # script but nothing ever invoked it -- no scheduled task, no caller anywhere
+        # in this repo. This loop already has the exact per-DB list (host/port/user/
+        # password/database) the script needs, so this is that missing trigger.
+        # Read-only diagnostics only (Query Store SELECTs + Azure Monitor reads);
+        # never modifies the target DB. Failures are logged and swallowed so a perf
+        # diagnostics error never blocks the existing MdbStatsUpdate flow below.
+        if ($db.db_type -and ($db.db_type -match '^(mssql|azuresql)$')) {
+            try {
+                $diagScript = Join-Path $ScriptDir "..\dpa-put-mssql-perfdiag.ps1"
+                if (Test-Path $diagScript) {
+                    $diagHost = if ($db.db_host) { $db.db_host } else { $db.ip }
+                    $diagPort = if ($db.db_port) { $db.db_port } else { "1433" }
+                    $diagDb = if ($db.db_database) { $db.db_database } elseif ($db.db_name) { $db.db_name } else { $null }
+                    $diagUser = if ($db.db_user) { $db.db_user } else { $db.user }
+                    $diagPass = if ($db.db_password) { $db.db_password } else { $db.pass }
+                    if ($diagHost -and $diagDb -and $diagUser) {
+                        $connStr = "Server=$diagHost,$diagPort;Initial Catalog=$diagDb;User ID=$diagUser;Password=$diagPass;TrustServerCertificate=True;Connect Timeout=15;"
+                        Write-GiipLog "INFO" "[DbMonitor] Running MSSQL perf diagnostics (giip-921/922) for mdb_id=$($db.mdb_id)..."
+                        & $diagScript -SqlConnectionString $connStr -MdbId ([int]$db.mdb_id)
+                    } else {
+                        Write-GiipLog "WARN" "[DbMonitor] Skipping perf diagnostics for mdb_id=$($db.mdb_id): missing host/database/user."
+                    }
+                }
+            } catch {
+                Write-GiipLog "WARN" "[DbMonitor] Perf diagnostics collection failed for mdb_id=$($db.mdb_id): $_"
+            }
+        }
+
         $stat = Get-GiipDbMetrics -DbInfo $db -LibDir $LibDir -Config $Config
         if ($stat) {
             # Create a clean, strictly-typed payload for the API


### PR DESCRIPTION
## Summary
giip-issue #922 follow-up ("수집이 안되고 있어" -- db_perf_diag isn't collecting). Root-caused
via a direct query against giipdb: `tKVS` has **zero** rows ever for `kType=database,
kFactor=db_perf_diag`, despite giip-921's collection feature (PR #26) being merged over two
weeks ago.

- **Bug 1 (fixed here): orphaned script.** `giipscripts/dpa-put-mssql-perfdiag.ps1` (added in
  #26) was never invoked by anything -- no scheduled task, no caller in this repo. Wired it into
  `DbMonitor.ps1`'s existing per-DB loop, which already fetches host/port/user/password/database
  for every managed DB via `ManagedDatabaseListForAgent`.
- **Bug 2 (fixed here): SQL schema bug.** `Get-MssqlPerfDiag`'s regression-query CTEs select
  `rs.query_id` from `sys.query_store_runtime_stats`, but that DMV has no `query_id` column
  (only `plan_id`). Every run threw `Invalid column name 'query_id'` and silently produced an
  empty regressions list. Fixed by joining `sys.query_store_plan` and using `p.query_id`.
  Companion fix in giipAgentLinux (same bug, ported 1:1 per #26's own description).

## Verification
Manually invoked the fixed script against `mdb_id=3` (giipdb itself, live Azure SQL) after
fetching its connection info via `giipdb/mgmt/execSQLFile.ps1`:
- Query Store status resolves `READ_WRITE` (was previously masked by the SQL error).
- Regression query now runs cleanly, no more "Invalid column name" error.
- KVS write still fails with `RstVal=411 ("Database not found or unauthorized")` -- this is a
  **separate, deeper issue**, not a code bug: `tManagedDatabase.gateway_lssn=71197` for csn=47's
  managed databases (mdb_id 3, 31) points at an lssn that belongs to a *different* tenant
  (lssn 71197 = cSn 33, "Lowy-DP01"). giipdb's tenant-isolation checks (in both
  `pApiManagedDatabaseListForAgentbySk` and `pApiKVSPutbySk`) correctly reject cross-tenant
  access -- so even with this PR's fixes, this specific host can never legitimately collect
  or write csn 47's db_perf_diag data. That's a gateway/topology reassignment decision, flagged
  to the user in giip-issue #922 rather than fixed unilaterally here.

## Test plan
- [x] PowerShell parser: zero syntax errors on both changed files.
- [x] Live manual run against mdb_id=3/giipdb: Query Store regression query error gone,
      `query_store_status=READ_WRITE`, `diagnosis=normal`.
- [ ] End-to-end KVS write success -- blocked on the gateway_lssn tenant mismatch above, not on
      this PR's changes. Needs the topology fix + a live scheduled run to confirm.

Not merging (per project convention) -- user reviews and merges after confirming Vercel/deploy
implications are understood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)