### PR TITLE
fix(db-perf-diag): apply stranded -RawList fix that missed PR #27's merge (giip-922)

### DIFF
--- a/giipscripts/modules/DbMonitor.ps1
+++ b/giipscripts/modules/DbMonitor.ps1
@@ -34,8 +34,13 @@ Write-GiipLog "INFO" "[DbMonitor] Starting DB Monitoring..."
 try {
     $reqData = @{ lssn = $Config.lssn }
     $reqJson = $reqData | ConvertTo-Json -Compress
-    $response = Invoke-GiipApiV2 -Config $Config -CommandText "ManagedDatabaseListForAgent lssn" -JsonData $reqJson
-    
+    # -RawList: this is a list endpoint (can return >1 managed database per lssn).
+    # Without it, Invoke-GiipApiV2's default single-object unwrap silently
+    # truncates the result to just the FIRST database returned (giip-issue #922
+    # follow-up -- found live: a customer with 2 managed databases on the same
+    # gateway only ever had the first one monitored).
+    $response = Invoke-GiipApiV2 -Config $Config -CommandText "ManagedDatabaseListForAgent lssn" -JsonData $reqJson -RawList
+
     $dbList = $null
     if ($response.data) { $dbList = $response.data }
     elseif ($response -is [Array]) { $dbList = $response }

--- a/lib/Common.ps1
+++ b/lib/Common.ps1
@@ -85,7 +85,14 @@ function Invoke-GiipApiV2 {
     param(
         [Parameter(Mandatory)][hashtable]$Config,
         [Parameter(Mandatory)][string]$CommandText,
-        [Parameter(Mandatory)][string]$JsonData
+        [Parameter(Mandatory)][string]$JsonData,
+        # giip-issue #922: most callers want a single object and rely on the
+        # $response.data[0] unwrap below. List endpoints (e.g.
+        # "ManagedDatabaseListForAgent") return multiple rows in $response.data
+        # and were silently truncated to just the first one. Pass -RawList to
+        # get the full, un-unwrapped $response back instead (existing callers
+        # are unaffected -- default behavior is unchanged).
+        [switch]$RawList
     )
     $effectiveToken = if ($Global:GiipSessionAK) { $Global:GiipSessionAK } else { $Config.sk }
     
@@ -135,6 +142,7 @@ function Invoke-GiipApiV2 {
             Write-GiipLog "DEBUG" "API Non-Success Response ($($response.RstVal)): $rawJson"
         }
         
+        if ($RawList) { return $response }
         if ($response.data -and $response.data.Count -gt 0) { return $response.data[0] }
         return $response
     } catch {


### PR DESCRIPTION
## 배경
PR #27(giip-922)이 머지된 직후, 같은 브랜치(`bot/task-giip-922-wire-perfdiag`)에 후속 커밋(`ManagedDatabaseListForAgent` 응답이 `$response.data[0]`로 잘려 mdb_id=31이 누락되던 버그 수정)이 추가로 푸시됐으나, PR이 이미 머지된 뒤라 그 커밋은 `main`에 반영되지 못하고 브랜치에만 남아있었습니다(`git compare main...bot/task-giip-922-wire-perfdiag` → ahead_by 2, 이 레포만 유일하게 2).

## 변경
`03f9f63`(Invoke-GiipApiV2의 `-RawList` opt-in 스위치 추가, DbMonitor.ps1이 이를 사용)를 `main` 위에 cherry-pick.

## 검증 (라이브)
이 브랜치로 `giipAgent3.ps1`을 실제로 실행해 확인:
- 수정 전(main): `Found 1 databases` — mdb_id=31 누락
- 수정 후(이 브랜치): `Found 2 databases`, mdb_id=3·31 둘 다 `db_perf_diag uploaded successfully` 확인, tKVS에 신규 레코드 확인

머지는 하지 않았습니다(사용자 확인 후 직접 머지 원칙).